### PR TITLE
Smach register exit signal

### DIFF
--- a/roseus_smach/src/state-machine-ros.l
+++ b/roseus_smach/src/state-machine-ros.l
@@ -142,7 +142,7 @@
      (setq init-tm (ros::time-now))
      ))
   (:register-exit-signal-hook
-    (&optional es userdata)
+    (&optional es userdata exit-signal-hook-func)
     (if (null es) (return-from :exit-state exit-state))
     (if (null (derivedp es state))
       (setq es (send self :state-machine :node es)))
@@ -151,19 +151,18 @@
     (send self :put 'userdata userdata)
     (let ((exit-signal-hook
             `(lambda-closure nil 0 0 (sig code)
+               (funcall ',exit-signal-hook-func (send ,self :get 'userdata))
                (send ,self :exit-signal-hook sig code ,es (send ,self :get 'userdata)))))
-      (unix:signal 2 exit-signal-hook)
-      (unix:signal 9 exit-signal-hook)
-      (unix:signal 15 exit-signal-hook)))
+      (unix:signal unix::sigint exit-signal-hook)))
   (:exit-signal-hook (sig code &optional es userdata)
     (if (null es) (return-from :exit-signal-hook (exit sig)))
     (ros::ros-error "exit-signal-hook called.~%")
+    (ros::ros-warn " Called ~A~%" (unix:signal unix::sigint))
+    (ros::ros-warn " Force transit to ~A.~%" es)
     (send sm :active-state es)
-    (send sm :append-goal-state es)
     (send self :publish-status userdata)
-    (send sm :execute userdata :step -1)
-    (ros::ros-error "exit-signal-hook finished.~%")
-    (exit sig))
+    (unix:signal unix::sigint 'ros::roseus-sigint-handler)  ;; if C-c twise, kill roseus
+    )
   ;;
   ;; utility for users
   ;;

--- a/roseus_smach/src/state-machine-ros.l
+++ b/roseus_smach/src/state-machine-ros.l
@@ -148,9 +148,10 @@
       (setq es (send self :state-machine :node es)))
     ;; update exit-state slot
     (setq exit-state es)
+    (send self :put 'userdata userdata)
     (let ((exit-signal-hook
             `(lambda-closure nil 0 0 (sig code)
-               (send ,self :exit-signal-hook sig code ,es ,userdata))))
+               (send ,self :exit-signal-hook sig code ,es (send ,self :get 'userdata)))))
       (unix:signal 2 exit-signal-hook)
       (unix:signal 9 exit-signal-hook)
       (unix:signal 15 exit-signal-hook)))

--- a/roseus_smach/src/state-machine-utils.l
+++ b/roseus_smach/src/state-machine-utils.l
@@ -2,7 +2,8 @@
 
 (defun exec-state-machine (sm &optional (mydata '(nil))
                            &key (spin t) (hz 1) (root-name "SM_ROOT")
-                                iterate exit-state)
+                                iterate exit-state
+                                (exit-signal-hook-func '(lambda-closure nil 0 0 (userdata) )))
   "Execute state machine
 
 Args:
@@ -11,7 +12,8 @@ Args:
   :spin (bool, default: t): call (send insp :spin-once) every time before executing state if T, call nothing otherwise.
   :hz (integer, default: 1): rate of execution loop
   :iterate (t or function): Enable asking [Y/N] on each action execution if given t, if function is given, then it is called before execution. If function returns nil, next action is not executed. Otherwise the action is executed
-  :exit-state (state or symbol): register smach's exit state for signals like sigint, sigterm and sigkill
+  :exit-state (state or symbol): register smach's exit state when cathing sigint signal
+  :exit-signal-hook-func (function): custom function when calling exit-state. Due to https://github.com/jsk-ros-pkg/jsk_roseus/issues/666#issuecomment-843640159 issue, you need to use '(lambda-closure nil 0 0 (userdata) ... , instead of #'(lambda (userdata) ...
 
 Returns:
   the last active state
@@ -22,7 +24,7 @@ Returns:
     (send insp :publish-structure) ;; publish once and latch
     (apply #'send sm :arg-keys (union (send sm :arg-keys) (mapcar #'car mydata)))
     (if exit-state
-      (send insp :register-exit-signal-hook exit-state mydata))
+      (send insp :register-exit-signal-hook exit-state mydata exit-signal-hook-func))
 
     (ros::rate hz)
     (while (ros::ok)

--- a/roseus_smach/src/state-machine.l
+++ b/roseus_smach/src/state-machine.l
@@ -156,9 +156,10 @@
          (warning-message 3 "Concurent state '~A' retuned outcome '~A' on termination~%"
                           (send (elt active-state i) :name) (elt ret i)))
        (warning-message 3 "Concurrent Outcomes ~A~%" (mapcar #'(lambda (s r) (cons (send s :name) r)) active-state ret)))
-     (warning-message 3 "State machine ~A '~A' :'~A' --> '~A'~%"
+     (warning-message 3 "State machine ~A '~A' :'~A' --> '~A'~A~%"
                       (if (send self :goal-test next-active-state) "terminating" "transitioning")
-                      (send-all active-state :name) (send-all (flatten trans-list) :name) (send-all next-active-state :name))
+                      (send-all active-state :name) (send-all (flatten trans-list) :name) (send-all next-active-state :name)
+                      (if userdata (format nil " with userdata '~A'" userdata) ""))
      (setq active-state (unique next-active-state))
      ret))
 


### PR DESCRIPTION
@knorth55 this my proposal to smach with exit signal https://github.com/jsk-ros-pkg/jsk_roseus/pull/717

I would like to force transit to given state by C-c, and let Smach to transit to goal state, instead of transit to state and terminates, because we may require several states to terminates, for example https://github.com/jsk-ros-pkg/jsk_robot/pull/1528/files#diff-b6f1331d5423001783eb8c671899dd722da52881e831ae028d34b1a0a54de356R184 expect to go to :end state and :goal state.

If the smach does not terminate after C-c, you can send C-c one more time, then it will kill roseus as usual. 
```
roseus sample/state-machine-ros-sample.l "(progn (exec-state-machine (smach-userdata) '((count . 1)) :exit-state :foo :exit-signal-hook-func '(lambda-closure nil 0 0 (userdata) (set-alist 'count 4 userdata))) (exit))"
roseus sample/state-machine-ros-sample.l "(progn (exec-state-machine (smach-simple) nil :exit-state :foo :exit-signal-hook-func '(lambda-closure nil 0 0 (userdata) (setq count 4))) (exit))"
```